### PR TITLE
Add demo size optimization pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.DS_Store*
+__pycache__/
+cloned_repos/
+node_test/node_modules/
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,76 @@
-Repository for commit analysis.
+# CPS CI/CD Analysis
+
+This repository contains utilities for analyzing Dockerfiles and Docker images, along with an LLM-driven pipeline that now focuses **only on image size**. The `llm_size_report.py` script clones the repository list, runs the size-only LLM pipeline, and exports a size report to Excel for comparing estimated waste before and after fixes.
+
+## Prerequisites
+- Python 3.10+
+- Docker installed and available on your PATH (required for validation/tests)
+- Git installed (for cloning repositories)
+- Network access to GitHub and the Gemini API
+- A Google Gemini API key exported as `GEMINI_API_KEY` or `GOOGLE_API_KEY` (optional `GEMINI_MODEL` to override the default model)
+- Python dependencies:
+  ```bash
+  pip install google-generativeai pandas openpyxl python-dotenv
+  ```
+
+## Inputs
+- `docker_repos.txt` should contain one repository URL per line (or comma-separated on a line). The default list includes the 99 repositories used for the study.
+- Dockerfiles will be cloned into `cloned_repos` by default; use `--clone-dir` to change the location.
+
+## Quick one-liner to apply size fixes
+Analyze a Dockerfile for size waste, apply the LLM-generated fixes directly to the file (with a `.bak` backup), and skip optional Docker build tests:
+
+```bash
+python -m llm_agents.dockerfile_pipeline path/to/Dockerfile --apply --skip-test
+```
+
+## Demo: generate an optimized copy of a Dockerfile
+If you want to keep the original file untouched and write a separate, size-optimized copy produced by the static analyzer plus the LLM fixer:
+
+```bash
+python size_optimization_pipeline.py path/to/Dockerfile --suffix .size-optimized
+```
+
+Pass `--output <path>` to control the exact output location or `--model <gemini-model>` to override the default Gemini model.
+
+## Apply size fixes across many repositories (writes separate copies)
+Run the analyzer and LLM fixer for every Dockerfile in your repo list, writing optimized copies alongside the originals using a suffix. This keeps the source Dockerfiles untouched while collecting the size-focused variants:
+
+```bash
+python llm_size_apply.py --repos-file docker_repos.txt --export-dir optimized_dockerfiles --suffix .llm-size
+```
+
+- Change `--suffix` if you prefer a different filename marker.
+- Drop `--export-dir` to keep only the in-repo copies; add `--first-only` to process just the first Dockerfile per repo.
+
+## Running the size report pipeline
+1. Ensure prerequisites are installed and the Gemini API key is set in your environment (or a `.env` file loaded via `python-dotenv`).
+2. Run the pipeline (analyzes the first Dockerfile per repo by default) to get **size-only** wasted-space estimates before and after fixes:
+   ```bash
+   python llm_size_report.py \
+     --repos-file docker_repos.txt \
+     --output llm_dockerfile_sizes.xlsx \
+     --clone-dir cloned_repos \
+     --first-only
+   ```
+3. To process every Dockerfile in each repo, omit `--first-only`:
+   ```bash
+   python llm_size_report.py --repos-file docker_repos.txt --output llm_dockerfile_sizes.xlsx
+   ```
+4. Add `--keep-cloned` if you want to preserve the cloned repositories for inspection.
+
+### One-off size review for a single Dockerfile
+If you only need size-related recommendations for one Dockerfile without writing changes, run the static analyzer first and then the size-focused LLM helper:
+
+```bash
+python size_static_llm_runner.py path/to/Dockerfile [--model <gemini-model>]
+```
+
+The script prints static recommendations filtered to size waste and then an LLM report with estimated wasted kilobytes.
+
+## Outputs
+- An Excel workbook (or CSV fallback) with before/after estimated wasted kilobytes and run metadata. The default file is `llm_dockerfile_sizes.xlsx` written to the repository root.
+
+## Troubleshooting
+- If Excel dependencies are missing, install `pandas` and `openpyxl`, or rely on the CSV fallback generated alongside the requested output path.
+- If Docker is unavailable, the validator and tester will be skipped; reports will still be produced from static analysis but build/run checks will be missing.

--- a/dockerfile_optimizer.py
+++ b/dockerfile_optimizer.py
@@ -1,0 +1,180 @@
+import csv
+import os
+import re
+import subprocess
+import sys
+from typing import Dict, List
+
+
+def parse_dockerfile(contents: str) -> List[Dict[str, str]]:
+    instructions: List[Dict[str, str]] = []
+    current = ""
+    for line in contents.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("#"):
+            if stripped.lower().startswith("# syntax="):
+                instructions.append({"instruction": "SYNTAX", "value": stripped})
+            continue
+        def remove_inline_comment(s: str) -> str:
+            in_quote = False
+            result: List[str] = []
+            for char in s:
+                if char in ('"', "'"):
+                    in_quote = not in_quote
+                if char == '#' and not in_quote:
+                    break
+                result.append(char)
+            return ''.join(result).rstrip()
+        stripped = remove_inline_comment(stripped)
+        if not stripped:
+            continue
+        if stripped.endswith("\\"):
+            current += stripped[:-1].rstrip() + " "
+            continue
+        current += stripped
+        parts = current.split(None, 1)
+        if not parts:
+            current = ""
+            continue
+        instr = parts[0].upper()
+        value = parts[1] if len(parts) > 1 else ""
+        instructions.append({"instruction": instr, "value": value})
+        current = ""
+    return instructions
+
+
+def analyse_instructions(instructions: List[Dict[str, str]]) -> List[Dict[str, str]]:
+    """Return size-focused recommendations for parsed Dockerfile instructions."""
+
+    recs: List[Dict[str, str]] = []
+    run_lines: List[tuple[int, str]] = []
+    for idx, item in enumerate(instructions):
+        instr = item["instruction"]
+        value = item["value"]
+        if instr == "RUN":
+            run_lines.append((idx, value))
+            if "apt-get" in value or "apt " in value:
+                if "--no-install-recommends" not in value:
+                    recs.append({
+                        "severity": "info",
+                        "instruction_index": idx,
+                        "message": "Use --no-install-recommends with apt-get to avoid unnecessary packages.",
+                    })
+                if not re.search(r"apt-get\s+clean", value) and not re.search(r"rm\s+-rf\s+/var/lib/apt/lists", value):
+                    recs.append({
+                        "severity": "info",
+                        "instruction_index": idx,
+                        "message": "Clean apt caches (e.g., apt-get clean && rm -rf /var/lib/apt/lists/*) to reduce image size.",
+                    })
+                if "apt-get update" in value and "apt-get install" not in value:
+                    recs.append({
+                        "severity": "info",
+                        "instruction_index": idx,
+                        "message": "Run apt-get update and install in the same RUN layer to improve caching and size.",
+                    })
+            if "pip install" in value and "--no-cache-dir" not in value:
+                recs.append({
+                    "severity": "info",
+                    "instruction_index": idx,
+                    "message": "Use --no-cache-dir with pip install to reduce image size.",
+                })
+            if "&&" not in value:
+                recs.append({
+                    "severity": "info",
+                    "instruction_index": idx,
+                    "message": "Combine multiple shell commands with '&&' in a single RUN to reduce layers.",
+                })
+        elif instr == "ADD":
+            if not re.search(r"\.tar(\.gz|\.bz2|\.xz)?", value):
+                recs.append({
+                    "severity": "info",
+                    "instruction_index": idx,
+                    "message": "Use COPY instead of ADD when not extracting archives to improve caching behaviour.",
+                })
+    if len(run_lines) > 3:
+        combined = " && ".join(cmd for _, cmd in run_lines)
+        if "apt-get" in combined:
+            recs.append({
+                "severity": "suggestion",
+                "instruction_index": -1,
+                "message": "Consider using multi-stage builds to separate build-time dependencies from the final runtime image.",
+            })
+    return recs
+
+
+def analyse_dockerfile(path: str) -> List[Dict[str, str]]:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            contents = f.read()
+    except FileNotFoundError:
+        return [{"severity": "error", "instruction_index": -1, "message": f"Dockerfile not found: {path}"}]
+    instructions = parse_dockerfile(contents)
+    return analyse_instructions(instructions)
+
+
+def find_dockerfiles(repo_path: str) -> List[str]:
+    matches: List[str] = []
+    for root, _dirs, files in os.walk(repo_path):
+        for name in files:
+            lname = name.lower()
+            if lname == "dockerfile" or lname.startswith("dockerfile."):
+                matches.append(os.path.join(root, name))
+    return matches
+
+
+def clone_repo(url: str, base_dir: str) -> str:
+    repo_name = url.rstrip("/").split("/")[-1]
+    dest = os.path.join(base_dir, repo_name)
+    if not os.path.exists(dest):
+        subprocess.run(["git", "clone", "--depth", "1", url, dest], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    return dest
+
+
+def process_csv(csv_path: str, limit: int | None = None) -> None:
+    repos_dir = "cloned_repos"
+    os.makedirs(repos_dir, exist_ok=True)
+    processed = 0
+    with open(csv_path, newline="", encoding="utf-8") as csvfile:
+        reader = csv.DictReader(csvfile)
+        for row in reader:
+            repo_url = row.get("Repository") or row.get("Repo")
+            if not repo_url:
+                continue
+            repo_path = clone_repo(repo_url, repos_dir)
+            for dockerfile in find_dockerfiles(repo_path):
+                print(f"Analyzing {dockerfile}")
+                recs = analyse_dockerfile(dockerfile)
+                for rec in recs:
+                    idx = rec["instruction_index"]
+                    loc = f"instruction {idx}" if idx >= 0 else "(general)"
+                    print(f"  {rec['severity'].upper()}: {loc} – {rec['message']}")
+            processed += 1
+            if limit is not None and processed >= limit:
+                break
+
+
+def main() -> None:
+    import argparse
+    parser = argparse.ArgumentParser(description="Analyze Dockerfiles from repositories listed in a CSV file.")
+    parser.add_argument("--csv", dest="csv_path", help="Path to CSV file containing repository URLs")
+    parser.add_argument("--limit", type=int, default=None, help="Limit number of repositories to process")
+    parser.add_argument("--repo-path", help="Analyze a single local repository instead of CSV", default=None)
+    args = parser.parse_args()
+    if args.repo_path:
+        for dockerfile in find_dockerfiles(args.repo_path):
+            print(f"Analyzing {dockerfile}")
+            recs = analyse_dockerfile(dockerfile)
+            for rec in recs:
+                idx = rec["instruction_index"]
+                loc = f"instruction {idx}" if idx >= 0 else "(general)"
+                print(f"  {rec['severity'].upper()}: {loc} – {rec['message']}")
+    elif args.csv_path:
+        process_csv(args.csv_path, limit=args.limit)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/llm_agents/__init__.py
+++ b/llm_agents/__init__.py
@@ -1,0 +1,15 @@
+from .dockerfile_llm_analyzer import DockerfileAnalyzer, find_dockerfiles
+from .dockerfile_fixer import DockerfileFixer
+from .dockerfile_validator import DockerfileValidator
+from .dockerfile_tester import DockerfileTester
+from .dockerfile_pipeline import DockerfilePipeline
+
+__all__ = [
+    "DockerfileAnalyzer",
+    "DockerfileFixer",
+    "DockerfileValidator",
+    "DockerfileTester",
+    "DockerfilePipeline",
+    "find_dockerfiles",
+]
+

--- a/llm_agents/dockerfile_fixer.py
+++ b/llm_agents/dockerfile_fixer.py
@@ -1,0 +1,58 @@
+from typing import Any, Dict, Optional
+
+
+class DockerfileFixer:
+    """Fixes Dockerfiles by applying size-focused LLM recommendations."""
+
+    def __init__(self, api_key: Optional[str] = None, model: Optional[str] = None):
+        try:
+            from .dockerfile_llm_analyzer import DockerfileAnalyzer
+        except ImportError:
+            from dockerfile_llm_analyzer import DockerfileAnalyzer
+
+        self.analyzer = DockerfileAnalyzer(api_key=api_key, model=model)
+        self.api_key = self.analyzer.api_key
+        self.model = self.analyzer.model
+
+    def _call_llm(self, prompt: str, system_prompt: Optional[str] = None) -> str:
+        return self.analyzer._call_llm(prompt, system_prompt)
+
+    def fix_dockerfile(self, original_dockerfile: str, analysis_results: Dict[str, Any]) -> Dict[str, Any]:
+        if not original_dockerfile.strip():
+            return {"success": False, "error": "Empty Dockerfile provided", "fixed_dockerfile": original_dockerfile}
+
+        llm_analysis = analysis_results.get("llm_analysis", {}) if analysis_results else {}
+        if not llm_analysis.get("success"):
+            return {
+                "success": False,
+                "error": llm_analysis.get("error", "Missing analysis results"),
+                "fixed_dockerfile": original_dockerfile,
+            }
+
+        llm_data = llm_analysis.get("data", {})
+        findings = llm_data.get("size_findings", [])
+        recommendations = llm_data.get("size_recommendations", [])
+
+        system_prompt = (
+            "You are a cautious Dockerfile editor. Apply only size-reduction fixes that match the findings."
+        )
+        summary_lines = ["SIZE FINDINGS:"] + [f"- {item}" for item in findings[:10]]
+        summary_lines.append("SIZE RECOMMENDATIONS:")
+        summary_lines += [f"- {item}" for item in recommendations[:10]]
+        summary = "\n".join(summary_lines)
+
+        user_prompt = f"""Update the Dockerfile to reduce image size following the recommendations below.
+Make minimal changes and keep all existing functionality.
+Return ONLY the updated Dockerfile (no markdown):
+
+ORIGINAL:
+```\n{original_dockerfile}\n```
+
+{summary}
+"""
+
+        response = self._call_llm(user_prompt, system_prompt)
+        if not response or response.startswith("LLM API error"):
+            return {"success": False, "error": response or "LLM failed", "fixed_dockerfile": original_dockerfile}
+
+        return {"success": True, "fixed_dockerfile": response.strip()}

--- a/llm_agents/dockerfile_llm_analyzer.py
+++ b/llm_agents/dockerfile_llm_analyzer.py
@@ -1,0 +1,148 @@
+import json
+import os
+from typing import Any, Dict, List, Optional
+
+try:
+    import google.generativeai as genai
+    GEMINI_AVAILABLE = True
+except ImportError:
+    GEMINI_AVAILABLE = False
+
+try:
+    from dotenv import load_dotenv
+    from pathlib import Path
+    load_dotenv(Path(__file__).parent / ".env")
+except ImportError:
+    pass
+
+
+class DockerfileAnalyzer:
+    """LLM-backed analyzer focused solely on image size opportunities."""
+
+    def __init__(self, api_key: Optional[str] = None, model: Optional[str] = None):
+        if not api_key:
+            api_key = os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
+        if not api_key:
+            raise ValueError("Gemini API key required. Set GEMINI_API_KEY or pass api_key.")
+
+        if not model:
+            model = os.getenv("GEMINI_MODEL", "gemini-2.5-flash-lite")
+
+        if not GEMINI_AVAILABLE:
+            raise ImportError("google-generativeai is required. Install with: pip install google-generativeai")
+
+        self.api_key = api_key
+        self.model = model
+        genai.configure(api_key=self.api_key)
+        self.client = genai.GenerativeModel(self.model)
+
+    def _call_llm(self, prompt: str, system_prompt: Optional[str] = None) -> str:
+        full_prompt = prompt if not system_prompt else f"{system_prompt}\n\n{prompt}"
+        try:
+            response = self.client.generate_content(
+                full_prompt,
+                generation_config={"temperature": 0.2, "max_output_tokens": 2000},
+            )
+            if hasattr(response, "text") and response.text:
+                return response.text.strip()
+            return ""
+        except Exception as exc:  # pragma: no cover - API failure handling
+            return f"LLM API error: {exc}"
+
+    def analyze_dockerfile(self, dockerfile_path: str) -> Dict[str, Any]:
+        try:
+            with open(dockerfile_path, "r", encoding="utf-8") as handle:
+                dockerfile_content = handle.read()
+        except FileNotFoundError:
+            return {"error": f"Dockerfile not found: {dockerfile_path}", "size_metrics": {}}
+
+        system_prompt = (
+            "You are a Docker image size expert. Identify only size-related inefficiencies and wasted space."
+        )
+        user_prompt = f"""Review this Dockerfile and return JSON:
+{{
+  "size_findings": ["list concrete causes of size bloat"],
+  "size_recommendations": ["actionable steps to reduce size"],
+  "estimated_wasted_space_kb": <number>
+}}
+Do not mention security or performance. Only talk about image size.
+Dockerfile:\n```\n{dockerfile_content}\n```"""
+
+        raw_response = self._call_llm(user_prompt, system_prompt)
+        if raw_response.startswith("LLM API error"):
+            return {
+                "dockerfile_path": dockerfile_path,
+                "llm_analysis": {"success": False, "error": raw_response, "data": {}},
+                "size_metrics": {"estimated_wasted_space_kb": 0},
+            }
+
+        cleaned = raw_response.strip()
+        if "```" in cleaned:
+            start = cleaned.find("```")
+            end = cleaned.rfind("```")
+            cleaned = cleaned[start + 3 : end].strip() if end > start else cleaned
+
+        try:
+            llm_data = json.loads(cleaned)
+        except json.JSONDecodeError:
+            llm_data = {}
+
+        wasted_kb = llm_data.get("estimated_wasted_space_kb", 0) or 0
+        try:
+            wasted_kb = float(wasted_kb)
+        except (TypeError, ValueError):
+            wasted_kb = 0.0
+
+        metrics = {"estimated_wasted_space_kb": round(wasted_kb, 2)}
+
+        analysis = {
+            "success": True,
+            "data": {
+                "size_findings": llm_data.get("size_findings", []),
+                "size_recommendations": llm_data.get("size_recommendations", []),
+                "estimated_wasted_space_kb": wasted_kb,
+            },
+            "raw_response": raw_response,
+        }
+
+        print(f"  [LLM Size Analysis] wasted_kb={metrics['estimated_wasted_space_kb']}")
+
+        return {"dockerfile_path": dockerfile_path, "llm_analysis": analysis, "size_metrics": metrics}
+
+    def print_analysis_report(self, analysis_result: Dict[str, Any]) -> None:
+        if "error" in analysis_result:
+            print(f"  ERROR: {analysis_result['error']}")
+            return
+
+        metrics = analysis_result.get("size_metrics", {})
+        llm_analysis = analysis_result.get("llm_analysis", {})
+        llm_data = llm_analysis.get("data", {}) if llm_analysis else {}
+
+        print("\n" + "=" * 60)
+        print("DOCKERFILE SIZE ANALYSIS")
+        print("=" * 60)
+        print(f"Estimated Wasted Space: {metrics.get('estimated_wasted_space_kb', 0):.2f} kB")
+
+        findings = llm_data.get("size_findings", [])
+        if findings:
+            print("\nSize Findings:")
+            for item in findings:
+                print(f"  - {item}")
+
+        recommendations = llm_data.get("size_recommendations", [])
+        if recommendations:
+            print("\nSize Recommendations:")
+            for rec in recommendations:
+                print(f"  * {rec}")
+
+        print("\n" + "=" * 60 + "\n")
+
+
+def find_dockerfiles(repo_path: str) -> List[str]:
+    matches: List[str] = []
+    for root, _dirs, files in os.walk(repo_path):
+        for name in files:
+            lname = name.lower()
+            if lname == "dockerfile" or lname.startswith("dockerfile."):
+                matches.append(os.path.join(root, name))
+    return matches

--- a/llm_agents/dockerfile_pipeline.py
+++ b/llm_agents/dockerfile_pipeline.py
@@ -1,0 +1,134 @@
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv(Path(__file__).parent / ".env")
+except ImportError:
+    pass
+
+if __package__ is None or __package__ == "":
+    current_dir = Path(__file__).parent
+    if str(current_dir) not in sys.path:
+        sys.path.insert(0, str(current_dir))
+    from dockerfile_llm_analyzer import DockerfileAnalyzer, find_dockerfiles
+    from dockerfile_fixer import DockerfileFixer
+    from dockerfile_validator import DockerfileValidator
+    from dockerfile_tester import DockerfileTester
+else:
+    from .dockerfile_llm_analyzer import DockerfileAnalyzer, find_dockerfiles
+    from .dockerfile_fixer import DockerfileFixer
+    from .dockerfile_validator import DockerfileValidator
+    from .dockerfile_tester import DockerfileTester
+
+
+class DockerfilePipeline:
+    """Runs size-focused analysis, fixing, validation, and optional build tests."""
+
+    def __init__(self, api_key: Optional[str] = None, model: Optional[str] = None, build_timeout: int = 300):
+        self.analyzer = DockerfileAnalyzer(api_key=api_key, model=model)
+        self.fixer = DockerfileFixer(api_key=api_key, model=model)
+        self.validator = DockerfileValidator(api_key=api_key, model=model)
+        self.tester = DockerfileTester(build_timeout=build_timeout)
+
+    def optimize_dockerfile(self, dockerfile_path: str, skip_test: bool = False) -> Dict[str, Any]:
+        results: Dict[str, Any] = {"dockerfile_path": dockerfile_path, "stages": {}}
+
+        print("\n" + "=" * 60)
+        print("STAGE 1: SIZE ANALYSIS")
+        print("=" * 60)
+        analysis = self.analyzer.analyze_dockerfile(dockerfile_path)
+        results["stages"]["analysis"] = {"success": "error" not in analysis, "result": analysis}
+        if "error" in analysis:
+            return results
+
+        with open(dockerfile_path, "r", encoding="utf-8") as handle:
+            original_content = handle.read()
+
+        print("\n" + "=" * 60)
+        print("STAGE 2: APPLY SIZE FIXES")
+        print("=" * 60)
+        fix_result = self.fixer.fix_dockerfile(original_content, analysis)
+        results["stages"]["fix"] = {"success": fix_result.get("success", False), "result": fix_result}
+        if not fix_result.get("success"):
+            return results
+        fixed_content = fix_result["fixed_dockerfile"]
+
+        print("\n" + "=" * 60)
+        print("STAGE 3: VALIDATE SIZE IMPROVEMENT")
+        print("=" * 60)
+        validation = self.validator.validate_fixes(analysis, fixed_content)
+        results["stages"]["validation"] = {"success": validation.get("success", False), "result": validation}
+
+        if not skip_test:
+            print("\n" + "=" * 60)
+            print("STAGE 4: OPTIONAL BUILD TEST")
+            print("=" * 60)
+            if not self.tester.docker_available:
+                results["stages"]["test"] = {"success": None, "skipped": True, "reason": "Docker CLI not available"}
+            else:
+                test_result = self.tester.test_dockerfile(
+                    fixed_content,
+                    dockerfile_path,
+                    os.path.dirname(dockerfile_path) or ".",
+                )
+                results["stages"]["test"] = {"success": test_result.get("success", False), "result": test_result}
+
+        results["original_dockerfile"] = original_content
+        results["fixed_dockerfile"] = fixed_content
+        results["original_analysis"] = analysis
+        results["success"] = results["stages"]["analysis"].get("success") and results["stages"]["fix"].get("success")
+        return results
+
+    def print_pipeline_report(self, results: Dict[str, Any]) -> None:
+        print("\n" + "=" * 60)
+        print("PIPELINE REPORT (SIZE ONLY)")
+        print("=" * 60)
+        if not results.get("success"):
+            print("Pipeline failed to complete all stages.")
+            return
+
+        validation = results.get("stages", {}).get("validation", {}).get("result", {})
+        if validation and validation.get("success"):
+            self.validator.print_comparison_report(validation)
+
+        print("Fixed Dockerfile Preview:\n")
+        fixed = results.get("fixed_dockerfile", "")
+        print(fixed[:800] + ("..." if len(fixed) > 800 else ""))
+        print("\n" + "=" * 60 + "\n")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Size-focused Dockerfile optimization pipeline")
+    parser.add_argument("dockerfile", help="Path to Dockerfile")
+    parser.add_argument("--skip-test", action="store_true", help="Skip docker build test")
+    parser.add_argument("--model", help="Override Gemini model")
+    parser.add_argument("--apply", action="store_true", help="Write the optimized Dockerfile back to disk")
+    parser.add_argument(
+        "--no-backup",
+        action="store_true",
+        help="Do not create a .bak copy before applying changes",
+    )
+    args = parser.parse_args()
+
+    pipeline = DockerfilePipeline(model=args.model)
+    outcome = pipeline.optimize_dockerfile(args.dockerfile, skip_test=args.skip_test)
+    pipeline.print_pipeline_report(outcome)
+
+    fixed_content = outcome.get("fixed_dockerfile") if outcome else None
+    if args.apply and outcome.get("success") and fixed_content:
+        if not args.no_backup:
+            backup_path = f"{args.dockerfile}.bak"
+            shutil.copy(args.dockerfile, backup_path)
+            print(f"Backup written to {backup_path}")
+
+        with open(args.dockerfile, "w", encoding="utf-8") as handle:
+            handle.write(fixed_content)
+        print(f"Applied size fixes to {args.dockerfile}")
+    elif args.apply:
+        print("Skipping write-back: no fixed Dockerfile produced.")

--- a/llm_agents/dockerfile_tester.py
+++ b/llm_agents/dockerfile_tester.py
@@ -1,0 +1,313 @@
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Dict, List, Optional, Any
+
+
+class DockerfileTester:    
+    def __init__(self, build_timeout: int = 300):
+        self.build_timeout = build_timeout
+        self.docker_available = self._check_docker_available()
+    
+    def _check_docker_available(self) -> bool:
+        return shutil.which("docker") is not None
+    
+    def test_dockerfile(
+        self,
+        dockerfile_content: str,
+        dockerfile_path: Optional[str] = None,
+        build_context: Optional[str] = None,
+        image_name: Optional[str] = None
+    ) -> Dict[str, Any]:
+        if not self.docker_available:
+            return {
+                "success": False,
+                "error": "Docker CLI not available",
+                "build_success": False,
+                "test_success": False
+            }
+        
+        syntax_result = self._validate_syntax(dockerfile_content)
+        if not syntax_result["valid"]:
+            return {
+                "success": False,
+                "error": "Dockerfile syntax validation failed",
+                "syntax_errors": syntax_result.get("errors", []),
+                "build_success": False,
+                "test_success": False
+            }
+        
+        temp_dockerfile = None
+        cleanup_needed = False
+        
+        try:
+            if dockerfile_path and os.path.exists(dockerfile_path):
+                dockerfile_to_use = dockerfile_path
+                if build_context is None:
+                    build_context = os.path.dirname(dockerfile_path) or "."
+            else:
+                temp_dockerfile = tempfile.NamedTemporaryFile(
+                    mode='w', suffix='.Dockerfile', delete=False
+                )
+                temp_dockerfile.write(dockerfile_content)
+                temp_dockerfile.close()
+                dockerfile_to_use = temp_dockerfile.name
+                cleanup_needed = True
+                if build_context is None:
+                    build_context = os.path.dirname(dockerfile_to_use) or "."
+            
+            if not image_name:
+                image_name = f"dockerfile-test-{int(time.time())}"
+            
+            print(f"  Building Docker image '{image_name}'...", end="", flush=True)
+            build_result = self._build_image(
+                dockerfile_to_use,
+                build_context,
+                image_name
+            )
+            print(" Done" if build_result["success"] else " Failed")
+            
+            if build_result["success"]:
+                print(f"\n  [Build Success] Time: {build_result.get('build_time', 0):.2f}s")
+                build_output = build_result.get("output", "")
+                if build_output:
+                    output_lines = build_output.strip().split('\n')
+                    if len(output_lines) > 5:
+                        print(f"  [Build Output] Last 5 lines:")
+                        for line in output_lines[-5:]:
+                            if line.strip():
+                                print(f"    {line[:100]}")
+                    else:
+                        print(f"  [Build Output] {build_output[:200]}")
+            else:
+                print(f"\n  [Build Failed] Time: {build_result.get('build_time', 0):.2f}s")
+                build_errors = build_result.get("errors", "")
+                if build_errors:
+                    error_lines = build_errors.strip().split('\n')
+                    print(f"  [Build Errors] Last 5 error lines:")
+                    for line in error_lines[-5:]:
+                        if line.strip():
+                            print(f"    {line[:100]}")
+            
+            test_result = {"test_success": False}
+            if build_result["success"]:
+                print(f"  Testing Docker image...", end="", flush=True)
+                test_result = self._test_image(image_name)
+                print("Completed" if test_result["test_success"] else " Failed")
+                
+                if test_result["test_success"]:
+                    test_output = test_result.get("output", "")
+                    print(f"\n  [Test Success] Container started and executed successfully")
+                    if test_output:
+                        print(f"  [Test Output] {test_output.strip()[:200]}")
+                else:
+                    test_output = test_result.get("output", "")
+                    print(f"\n  [Test Failed] Container test failed")
+                    if test_output:
+                        print(f"  [Test Error] {test_output.strip()[:200]}")
+            
+            return {
+                "success": build_result["success"] and test_result.get("test_success", False),
+                "build_success": build_result["success"],
+                "build_time": build_result.get("build_time", 0),
+                "build_output": build_result.get("output", ""),
+                "build_errors": build_result.get("errors", ""),
+                "test_success": test_result.get("test_success", False),
+                "test_output": test_result.get("output", ""),
+                "image_name": image_name,
+                "syntax_valid": True
+            }
+        
+        finally:
+            if cleanup_needed and temp_dockerfile and os.path.exists(temp_dockerfile.name):
+                try:
+                    os.unlink(temp_dockerfile.name)
+                except:
+                    pass
+    
+    def _validate_syntax(self, dockerfile_content: str) -> Dict[str, Any]:
+        if not dockerfile_content.strip():
+            return {"valid": False, "errors": ["Dockerfile is empty"]}
+        
+        lines = dockerfile_content.split('\n')
+        has_from = False
+        errors = []
+        
+        for i, line in enumerate(lines, 1):
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#"):
+                if stripped.upper().startswith("FROM"):
+                    has_from = True
+                    break
+        
+        if not has_from:
+            errors.append("Dockerfile must start with a FROM instruction")
+        
+        return {
+            "valid": len(errors) == 0,
+            "errors": errors
+        }
+    
+    def _build_image(
+        self,
+        dockerfile_path: str,
+        build_context: str,
+        image_name: str
+    ) -> Dict[str, Any]:
+        start_time = time.time()
+        
+        try:
+            print(f"\n  [Build Command] docker build -f {dockerfile_path} -t {image_name} {build_context}")
+            
+            result = subprocess.run(
+                [
+                    "docker", "build",
+                    "-f", dockerfile_path,
+                    "-t", image_name,
+                    build_context
+                ],
+                capture_output=True,
+                text=True,
+                timeout=self.build_timeout,
+                check=False
+            )
+            
+            build_time = time.time() - start_time
+            
+            if result.returncode == 0:
+                output_lines = result.stdout.split('\n')
+                step_count = len([l for l in output_lines if 'Step' in l and '/' in l])
+                final_size = None
+                for line in reversed(output_lines):
+                    if 'Successfully tagged' in line:
+                        break
+                    if 'MB' in line or 'GB' in line:
+                        parts = line.split()
+                        for i, part in enumerate(parts):
+                            if part in ['MB', 'GB', 'KB'] and i > 0:
+                                final_size = ' '.join(parts[max(0, i-1):i+1])
+                                break
+                        if final_size:
+                            break
+                
+                return {
+                    "success": True,
+                    "build_time": round(build_time, 2),
+                    "output": result.stdout,
+                    "errors": "",
+                    "step_count": step_count,
+                    "final_size": final_size
+                }
+            else:
+                return {
+                    "success": False,
+                    "build_time": round(build_time, 2),
+                    "output": result.stdout,
+                    "errors": result.stderr,
+                    "returncode": result.returncode
+                }
+        
+        except subprocess.TimeoutExpired:
+            return {
+                "success": False,
+                "build_time": self.build_timeout,
+                "output": "",
+                "errors": f"Build timed out after {self.build_timeout} seconds"
+            }
+        except Exception as e:
+            return {
+                "success": False,
+                "build_time": time.time() - start_time,
+                "output": "",
+                "errors": str(e)
+            }
+    
+    def _test_image(self, image_name: str) -> Dict[str, Any]:
+        try:
+            test_command = ["docker", "run", "--rm", "--name", f"{image_name}-test", image_name, "echo", "test"]
+            print(f"\n  [Test Command] {' '.join(test_command)}")
+            
+            result = subprocess.run(
+                test_command,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False
+            )
+            
+            if result.returncode == 0:
+                return {
+                    "test_success": True,
+                    "output": result.stdout,
+                    "returncode": result.returncode
+                }
+            else:
+                return {
+                    "test_success": False,
+                    "output": result.stderr or result.stdout,
+                    "returncode": result.returncode
+                }
+        
+        except subprocess.TimeoutExpired:
+            return {
+                "test_success": False,
+                "output": "Container test timed out after 30 seconds"
+            }
+        except Exception as e:
+            return {
+                "test_success": False,
+                "output": str(e)
+            }
+    
+    def cleanup_image(self, image_name: str) -> bool:
+        if not self.docker_available:
+            return False
+        
+        try:
+            subprocess.run(
+                ["docker", "rmi", "-f", image_name],
+                capture_output=True,
+                check=False
+            )
+            return True
+        except:
+            return False
+    
+    def print_test_report(self, test_results: Dict[str, Any]) -> None:
+        print("\n" + "="*60)
+        print("DOCKERFILE TEST REPORT")
+        print("="*60)
+        
+        if not test_results.get("success"):
+            print("\n[ERROR] Test failed")
+            if test_results.get("error"):
+                print(f"  Error: {test_results['error']}")
+            if test_results.get("syntax_errors"):
+                print(f"  Syntax Errors:")
+                for err in test_results["syntax_errors"]:
+                    print(f"    - {err}")
+            if test_results.get("build_errors"):
+                print(f"  Build Errors:")
+                print(f"    {test_results['build_errors'][:500]}")
+            print("\n" + "="*60 + "\n")
+            return
+        
+        print(f"\nBUILD RESULTS:")
+        print(f"  Status: {'SUCCESS' if test_results.get('build_success') else 'FAILED'}")
+        if test_results.get("build_time"):
+            print(f"  Build Time: {test_results.get('build_time', 0):.2f} seconds")
+        
+        print(f"\nTEST RESULTS:")
+        print(f"  Status: {'SUCCESS' if test_results.get('test_success') else 'FAILED'}")
+        
+        if test_results.get("image_name"):
+            print(f"  Image Name: {test_results['image_name']}")
+        
+        print("\n" + "="*60 + "\n")
+
+
+
+

--- a/llm_agents/dockerfile_validator.py
+++ b/llm_agents/dockerfile_validator.py
@@ -1,0 +1,72 @@
+from typing import Any, Dict, Optional
+
+
+class DockerfileValidator:
+    """Re-analyzes fixed Dockerfiles and compares size-only metrics."""
+
+    def __init__(self, api_key: Optional[str] = None, model: Optional[str] = None):
+        try:
+            from .dockerfile_llm_analyzer import DockerfileAnalyzer
+        except ImportError:
+            from dockerfile_llm_analyzer import DockerfileAnalyzer
+        self.analyzer = DockerfileAnalyzer(api_key=api_key, model=model)
+
+    def validate_fixes(self, original_analysis: Dict[str, Any], fixed_dockerfile: str) -> Dict[str, Any]:
+        import tempfile
+        import os
+
+        if not original_analysis:
+            return {"success": False, "error": "Invalid original analysis"}
+
+        if not fixed_dockerfile.strip():
+            return {"success": False, "error": "Empty fixed Dockerfile"}
+
+        temp_path = None
+        try:
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".Dockerfile", delete=False) as handle:
+                handle.write(fixed_dockerfile)
+                temp_path = handle.name
+
+            print("  Validating fixes...", end="", flush=True)
+            fixed_analysis = self.analyzer.analyze_dockerfile(temp_path)
+            print(" Done")
+        finally:
+            if temp_path and os.path.exists(temp_path):
+                try:
+                    os.unlink(temp_path)
+                except OSError:
+                    pass
+
+        if "error" in fixed_analysis:
+            return {"success": False, "error": fixed_analysis.get("error", "Validation failed")}
+
+        original_metrics = original_analysis.get("size_metrics", {})
+        fixed_metrics = fixed_analysis.get("size_metrics", {})
+        improvements = self._improvement(original_metrics, fixed_metrics)
+
+        return {
+            "success": True,
+            "original_metrics": original_metrics,
+            "fixed_metrics": fixed_metrics,
+            "improvements": improvements,
+            "fixed_analysis": fixed_analysis,
+        }
+
+    def _improvement(self, original: Dict[str, float], fixed: Dict[str, float]) -> Dict[str, Any]:
+        wasted_before = float(original.get("estimated_wasted_space_kb", 0) or 0)
+        wasted_after = float(fixed.get("estimated_wasted_space_kb", 0) or 0)
+        return {
+            "wasted_space_delta_kb": round(wasted_after - wasted_before, 2),
+        }
+
+    def print_comparison_report(self, validation_results: Dict[str, Any]) -> None:
+        print("\n" + "=" * 60)
+        print("SIZE VALIDATION REPORT")
+        print("=" * 60)
+        original = validation_results.get("original_metrics", {})
+        fixed = validation_results.get("fixed_metrics", {})
+        improvements = validation_results.get("improvements", {})
+        print(f"Original Estimated Waste (kB): {original.get('estimated_wasted_space_kb', 0):.2f}")
+        print(f"Fixed Estimated Waste (kB): {fixed.get('estimated_wasted_space_kb', 0):.2f}")
+        print(f"Wasted Space Delta (kB): {improvements.get('wasted_space_delta_kb', 0):.2f}")
+        print("\n" + "=" * 60 + "\n")

--- a/llm_size_apply.py
+++ b/llm_size_apply.py
@@ -1,0 +1,133 @@
+"""Batch-apply size-focused LLM Dockerfile fixes without overwriting originals.
+
+This helper clones repositories, runs the size analyzer, generates
+LLM-backed fixes, and writes each optimized Dockerfile alongside the
+original using a configurable suffix. Optionally, optimized files can be
+exported to an output directory for safekeeping.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+from llm_agents.dockerfile_llm_analyzer import DockerfileAnalyzer, find_dockerfiles
+from llm_agents.dockerfile_fixer import DockerfileFixer
+
+
+def read_repo_list(repos_file: Path) -> List[str]:
+    urls: List[str] = []
+    with repos_file.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("http"):
+                urls.append(line)
+            else:
+                urls.extend([part.strip() for part in line.split(",") if part.strip().startswith("http")])
+    return urls
+
+
+def clone_repo(repo_url: str, base_dir: Path) -> Path:
+    base_dir.mkdir(parents=True, exist_ok=True)
+    repo_name = repo_url.rstrip("/").split("/")[-1].replace(".git", "")
+    dest = base_dir / repo_name
+    if dest.exists():
+        return dest
+    subprocess.run(["git", "clone", "--depth", "1", repo_url, str(dest)], check=False)
+    return dest
+
+
+def write_optimized_copy(
+    original_path: Path,
+    optimized_contents: str,
+    suffix: str,
+    export_root: Optional[Path],
+    repo_root: Path,
+) -> Path:
+    target_path = original_path.with_name(original_path.name + suffix)
+    target_path.write_text(optimized_contents, encoding="utf-8")
+
+    if export_root:
+        export_root.mkdir(parents=True, exist_ok=True)
+        relative = original_path.relative_to(repo_root)
+        export_path = export_root / relative.with_name(relative.name + suffix)
+        export_path.parent.mkdir(parents=True, exist_ok=True)
+        export_path.write_text(optimized_contents, encoding="utf-8")
+    return target_path
+
+
+def process_dockerfile(
+    dockerfile_path: Path,
+    analyzer: DockerfileAnalyzer,
+    fixer: DockerfileFixer,
+    suffix: str,
+    export_root: Optional[Path],
+    repo_root: Path,
+) -> None:
+    print(f"  Analyzing {dockerfile_path}")
+    analysis = analyzer.analyze_dockerfile(str(dockerfile_path))
+    llm_analysis = analysis.get("llm_analysis", {})
+    if not llm_analysis.get("success"):
+        print(f"    Skipped (analysis failed): {llm_analysis.get('error', 'Unknown error')}")
+        return
+
+    fix_result = fixer.fix_dockerfile(dockerfile_path.read_text(encoding="utf-8"), analysis)
+    if not fix_result.get("success"):
+        print(f"    Skipped (fix failed): {fix_result.get('error', 'Unknown error')}")
+        return
+
+    optimized_path = write_optimized_copy(
+        dockerfile_path,
+        fix_result["fixed_dockerfile"],
+        suffix=suffix,
+        export_root=export_root,
+        repo_root=repo_root,
+    )
+    print(f"    Wrote optimized copy -> {optimized_path}")
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Apply size-focused LLM fixes to Dockerfiles across repos")
+    parser.add_argument("--repos-file", default="docker_repos.txt", help="Text file with repository URLs (default: docker_repos.txt)")
+    parser.add_argument("--clone-dir", default="cloned_repos", help="Directory to place cloned repositories")
+    parser.add_argument("--keep-cloned", action="store_true", help="Keep cloned repositories after processing")
+    parser.add_argument("--suffix", default=".llm-size", help="Suffix for optimized Dockerfile copies (default: .llm-size)")
+    parser.add_argument("--export-dir", default=None, help="Optional directory to also store optimized copies outside the repo")
+    parser.add_argument("--first-only", action="store_true", help="Only process the first Dockerfile found in each repo")
+    parser.add_argument("--api-key", default=None, help="Gemini API key (default: env GEMINI_API_KEY or GOOGLE_API_KEY)")
+    parser.add_argument("--model", default=None, help="Gemini model override")
+    args = parser.parse_args(argv)
+
+    api_key = args.api_key or os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
+    model = args.model or os.getenv("GEMINI_MODEL")
+
+    analyzer = DockerfileAnalyzer(api_key=api_key, model=model)
+    fixer = DockerfileFixer(api_key=api_key, model=model)
+
+    repos = read_repo_list(Path(args.repos_file))
+    clone_dir = Path(args.clone_dir)
+    export_root = Path(args.export_dir) if args.export_dir else None
+
+    for idx, repo_url in enumerate(repos, start=1):
+        print(f"[{idx}/{len(repos)}] Processing {repo_url}")
+        repo_path = clone_repo(repo_url, clone_dir)
+        dockerfiles = find_dockerfiles(str(repo_path))
+        if not dockerfiles:
+            print("  No Dockerfiles found")
+        else:
+            to_process = dockerfiles[:1] if args.first_only else dockerfiles
+            for dockerfile in to_process:
+                process_dockerfile(Path(dockerfile), analyzer, fixer, args.suffix, export_root, repo_path)
+        if not args.keep_cloned and repo_path.exists():
+            shutil.rmtree(repo_path)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/llm_size_report.py
+++ b/llm_size_report.py
@@ -1,0 +1,225 @@
+"""Run size-focused LLM Dockerfile optimization across repositories and export before/after waste estimates.
+
+This script wires the llm_agents pipeline into a batch runner that:
+- clones repositories from a list
+- locates Dockerfiles
+- runs LLM analysis + fixes
+- re-analyzes the fixed Dockerfile to quantify estimated wasted kilobytes
+- writes an Excel report capturing size findings before and after fixes
+
+The script is intentionally resilient: repositories without Dockerfiles,
+analysis failures, or missing dependencies are recorded as errors instead
+of aborting the entire run.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+from llm_agents.dockerfile_llm_analyzer import DockerfileAnalyzer, find_dockerfiles
+from llm_agents.dockerfile_fixer import DockerfileFixer
+from llm_agents.dockerfile_validator import DockerfileValidator
+
+
+@dataclass
+class SizeRecord:
+    repo_url: str
+    dockerfile_path: str
+    original_wasted_kb: Optional[float] = None
+    fixed_wasted_kb: Optional[float] = None
+    wasted_space_delta_kb: Optional[float] = None
+    llm_error: Optional[str] = None
+    fix_error: Optional[str] = None
+    validation_error: Optional[str] = None
+
+
+class SizeReportRunner:
+    def __init__(self, api_key: Optional[str], model: Optional[str], build_timeout: int = 300) -> None:
+        self.analyzer = DockerfileAnalyzer(api_key=api_key, model=model)
+        self.fixer = DockerfileFixer(api_key=api_key, model=model)
+        self.validator = DockerfileValidator(api_key=api_key, model=model)
+        self.build_timeout = build_timeout
+
+    def run_for_repo(self, repo_url: str, repo_dir: Path, first_only: bool) -> List[SizeRecord]:
+        dockerfiles = find_dockerfiles(str(repo_dir))
+        if not dockerfiles:
+            return [SizeRecord(repo_url=repo_url, dockerfile_path="", llm_error="No Dockerfiles found")]
+
+        if first_only:
+            dockerfiles = dockerfiles[:1]
+
+        records: List[SizeRecord] = []
+        for dockerfile_path in dockerfiles:
+            records.append(self._record_single(repo_url, Path(dockerfile_path)))
+        return records
+
+    def _record_single(self, repo_url: str, dockerfile_path: Path) -> SizeRecord:
+        original_analysis = self.analyzer.analyze_dockerfile(str(dockerfile_path))
+        llm_analysis = original_analysis.get("llm_analysis", {})
+        if not llm_analysis.get("success", False):
+            error = llm_analysis.get("error") or original_analysis.get("error") or "LLM analysis failed"
+            return SizeRecord(
+                repo_url=repo_url,
+                dockerfile_path=str(dockerfile_path),
+                llm_error=error,
+                **self._metric_fields(original_analysis.get("size_metrics", {}), prefix="original_"),
+            )
+
+        fix_result = self.fixer.fix_dockerfile(dockerfile_path.read_text(encoding="utf-8"), original_analysis)
+        if not fix_result.get("success"):
+            return SizeRecord(
+                repo_url=repo_url,
+                dockerfile_path=str(dockerfile_path),
+                fix_error=fix_result.get("error", "Failed to generate fix"),
+                **self._metric_fields(original_analysis.get("size_metrics", {}), prefix="original_"),
+            )
+
+        validation = self.validator.validate_fixes(original_analysis, fix_result["fixed_dockerfile"])
+        fixed_metrics = validation.get("fixed_metrics", {})
+        improvements = validation.get("improvements", {})
+        record = SizeRecord(
+            repo_url=repo_url,
+            dockerfile_path=str(dockerfile_path),
+            **self._metric_fields(original_analysis.get("size_metrics", {}), prefix="original_"),
+            **self._metric_fields(fixed_metrics, prefix="fixed_"),
+            wasted_space_delta_kb=self._improvement(improvements, "wasted_space_delta_kb"),
+        )
+
+        if not validation.get("success"):
+            record.validation_error = validation.get("error", "Validation failed")
+
+        return record
+
+    @staticmethod
+    def _metric_fields(metrics: Dict[str, float], prefix: str) -> Dict[str, Optional[float]]:
+        return {
+            f"{prefix}wasted_kb": metrics.get("estimated_wasted_space_kb"),
+        }
+
+    @staticmethod
+    def _improvement(improvements: Dict[str, float], key: str) -> Optional[float]:
+        return improvements.get(key)
+
+
+def read_repo_list(repos_file: Path) -> List[str]:
+    urls: List[str] = []
+    with repos_file.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("http"):
+                urls.append(line)
+            else:
+                parts = [p.strip() for p in line.split(",") if "http" in p]
+                urls.extend(parts)
+    return urls
+
+
+def clone_repo(repo_url: str, base_dir: Path) -> Path:
+    base_dir.mkdir(parents=True, exist_ok=True)
+    repo_name = repo_url.rstrip("/").split("/")[-1].replace(".git", "")
+    dest = base_dir / repo_name
+    if dest.exists():
+        return dest
+
+    subprocess.run(["git", "clone", "--depth", "1", repo_url, str(dest)], check=False)
+    return dest
+
+
+def export_size_report(records: Sequence[SizeRecord], output_path: Path) -> None:
+    rows = [asdict(r) for r in records]
+
+    try:
+        import pandas as pd
+
+        df = pd.DataFrame(rows)
+        with pd.ExcelWriter(output_path, engine="openpyxl") as writer:
+            df.to_excel(writer, index=False, sheet_name="size_metrics")
+            meta = pd.DataFrame(
+                {
+                    "run_timestamp": [dt.datetime.utcnow().isoformat() + "Z"],
+                    "repo_count": [len({r.repo_url for r in records})],
+                    "dockerfile_count": [len(records)],
+                }
+            )
+            meta.to_excel(writer, index=False, sheet_name="run_metadata")
+        return
+    except ImportError:
+        pass
+
+    try:
+        from openpyxl import Workbook
+
+        wb = Workbook()
+        ws = wb.active
+        ws.title = "size_metrics"
+
+        headers = list(rows[0].keys()) if rows else []
+        if headers:
+            ws.append(headers)
+            for row in rows:
+                ws.append([row.get(h) for h in headers])
+
+        meta_ws = wb.create_sheet("run_metadata")
+        meta_ws.append(["run_timestamp", "repo_count", "dockerfile_count"])
+        meta_ws.append([dt.datetime.utcnow().isoformat() + "Z", len({r.repo_url for r in records}), len(records)])
+
+        wb.save(output_path)
+        return
+    except Exception as exc:  # pragma: no cover - best-effort fallback
+        sys.stderr.write(f"Failed to write Excel file: {exc}\n")
+
+    csv_path = output_path.with_suffix(".csv")
+    with csv_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()) if rows else [])
+        if rows:
+            writer.writeheader()
+            writer.writerows(rows)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Batch LLM Dockerfile size report generator")
+    parser.add_argument("--repos-file", default="docker_repos.txt", help="File with repository URLs (default: docker_repos.txt)")
+    parser.add_argument("--output", default="llm_dockerfile_sizes.xlsx", help="Excel output path (default: llm_dockerfile_sizes.xlsx)")
+    parser.add_argument("--clone-dir", default="cloned_repos", help="Directory to place cloned repositories")
+    parser.add_argument("--keep-cloned", action="store_true", help="Keep cloned repositories after processing")
+    parser.add_argument("--first-only", action="store_true", help="Analyze only the first Dockerfile found in each repo")
+    parser.add_argument("--api-key", default=None, help="Gemini API key (default: env GEMINI_API_KEY or GOOGLE_API_KEY)")
+    parser.add_argument("--model", default=None, help="Gemini model name (default: env GEMINI_MODEL)")
+    parser.add_argument("--build-timeout", type=int, default=300, help="Docker build timeout for tests (default: 300)")
+    args = parser.parse_args(argv)
+
+    api_key = args.api_key or os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
+    model = args.model or os.getenv("GEMINI_MODEL")
+
+    repos = read_repo_list(Path(args.repos_file))
+    clone_dir = Path(args.clone_dir)
+
+    runner = SizeReportRunner(api_key=api_key, model=model, build_timeout=args.build_timeout)
+
+    records: List[SizeRecord] = []
+    for idx, repo_url in enumerate(repos, start=1):
+        print(f"[{idx}/{len(repos)}] Processing {repo_url}")
+        repo_path = clone_repo(repo_url, clone_dir)
+        try:
+            records.extend(runner.run_for_repo(repo_url, repo_path, args.first_only))
+        finally:
+            if not args.keep_cloned and repo_path.exists():
+                shutil.rmtree(repo_path)
+
+    export_size_report(records, Path(args.output))
+    print(f"\nWrote size report for {len(records)} Dockerfile(s) to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/size_optimization_pipeline.py
+++ b/size_optimization_pipeline.py
@@ -1,0 +1,112 @@
+"""Demo pipeline to generate size-focused Dockerfile improvements.
+
+This script runs the static size analyzer, then the LLM size analyzer
+and fixer, and writes the optimized Dockerfile as a separate file so
+the original remains untouched.
+"""
+
+import argparse
+from pathlib import Path
+from typing import Any, Dict, List
+
+from dockerfile_optimizer import analyse_instructions, parse_dockerfile
+from llm_agents.dockerfile_fixer import DockerfileFixer
+from llm_agents.dockerfile_llm_analyzer import DockerfileAnalyzer
+
+
+def _print_recommendations(recs: List[Dict[str, Any]]) -> None:
+    if not recs:
+        print("  None")
+        return
+    for rec in recs:
+        message = rec.get("message") or ""
+        severity = rec.get("severity", "info")
+        print(f"  - [{severity}] {message}")
+
+
+def run_pipeline(dockerfile_path: str, output_path: Path, model: str | None = None) -> Dict[str, Any]:
+    dockerfile = Path(dockerfile_path)
+    if not dockerfile.exists():
+        return {"success": False, "error": f"Dockerfile not found: {dockerfile_path}"}
+
+    with dockerfile.open("r", encoding="utf-8") as handle:
+        original_content = handle.read()
+
+    print("\nStep 1: Static size recommendations")
+    instructions = parse_dockerfile(original_content)
+    static_recs = analyse_instructions(instructions)
+    _print_recommendations(static_recs)
+
+    print("\nStep 2: LLM size optimization")
+    analyzer = DockerfileAnalyzer(model=model)
+    analysis = analyzer.analyze_dockerfile(str(dockerfile))
+    analyzer.print_analysis_report(analysis)
+
+    if not isinstance(analysis, dict):
+        return {"success": False, "error": "Unexpected analysis response"}
+
+    llm_analysis = analysis.get("llm_analysis", {})
+    if isinstance(llm_analysis, str):
+        llm_analysis = {"success": False, "error": llm_analysis, "data": {}}
+        analysis["llm_analysis"] = llm_analysis
+
+    if analysis.get("error"):
+        return {"success": False, "error": analysis.get("error")}
+
+    if not llm_analysis or not llm_analysis.get("success"):
+        return {"success": False, "error": llm_analysis.get("error", "LLM analysis failed")}
+
+    print("\nStep 3: Apply LLM size fixes")
+    fixer = DockerfileFixer(api_key=analyzer.api_key, model=model)
+    fix_result = fixer.fix_dockerfile(original_content, {"llm_analysis": llm_analysis})
+
+    if not isinstance(fix_result, dict):
+        return {"success": False, "error": "Unexpected fix response"}
+
+    if not fix_result.get("success"):
+        return {"success": False, "error": fix_result.get("error", "LLM fixer failed")}
+
+    fixed_content = fix_result.get("fixed_dockerfile", "")
+    output_path.write_text(fixed_content, encoding="utf-8")
+    print(f"  Wrote optimized Dockerfile to {output_path}")
+
+    return {
+        "success": True,
+        "original": original_content,
+        "fixed": fixed_content,
+        "analysis": analysis,
+        "fix_result": fix_result,
+        "output_path": str(output_path),
+    }
+
+
+def default_output_path(dockerfile_path: str, suffix: str) -> Path:
+    path = Path(dockerfile_path)
+    new_name = path.name + suffix if path.name != "Dockerfile" else f"Dockerfile{suffix}"
+    return path.with_name(new_name)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run size-only Dockerfile optimization and save a copy")
+    parser.add_argument("dockerfile", help="Path to the Dockerfile to analyze")
+    parser.add_argument("--model", help="Gemini model override")
+    parser.add_argument(
+        "--suffix",
+        default=".size-optimized",
+        help="Filename suffix for the optimized Dockerfile copy",
+    )
+    parser.add_argument(
+        "--output",
+        help="Explicit output path for the optimized Dockerfile. Overrides --suffix when set.",
+    )
+    args = parser.parse_args()
+
+    output = Path(args.output) if args.output else default_output_path(args.dockerfile, args.suffix)
+    result = run_pipeline(args.dockerfile, output_path=output, model=args.model)
+
+    if not result.get("success"):
+        print(f"ERROR: {result.get('error')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/size_static_llm_runner.py
+++ b/size_static_llm_runner.py
@@ -1,0 +1,60 @@
+"""Run static Dockerfile analysis then size-focused LLM review."""
+
+import argparse
+import os
+from typing import List
+
+from dockerfile_optimizer import analyse_instructions, parse_dockerfile
+from llm_agents.dockerfile_llm_analyzer import DockerfileAnalyzer
+
+SIZE_KEYWORDS = (
+    "size",
+    "layer",
+    "cache",
+    "no-cache",
+    "multi-stage",
+    "apt-get clean",
+    "rm -rf /var/lib/apt/lists",
+    "--no-install-recommends",
+    "--no-cache-dir",
+)
+
+
+def size_related(recommendations: List[dict]) -> List[dict]:
+    filtered = []
+    for rec in recommendations:
+        message = rec.get("message", "").lower()
+        if any(keyword in message for keyword in SIZE_KEYWORDS):
+            filtered.append(rec)
+    return filtered
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Static + LLM size analysis for a Dockerfile")
+    parser.add_argument("dockerfile", help="Path to Dockerfile")
+    parser.add_argument("--model", help="Gemini model override")
+    args = parser.parse_args()
+
+    if not os.path.exists(args.dockerfile):
+        raise SystemExit(f"Dockerfile not found: {args.dockerfile}")
+
+    with open(args.dockerfile, "r", encoding="utf-8") as handle:
+        contents = handle.read()
+
+    instructions = parse_dockerfile(contents)
+    static_recs = size_related(analyse_instructions(instructions))
+
+    print("STATIC SIZE RECOMMENDATIONS:")
+    if static_recs:
+        for rec in static_recs:
+            print(f" - [{rec.get('severity','info')}] {rec.get('message')}")
+    else:
+        print(" - None")
+
+    analyzer = DockerfileAnalyzer(model=args.model)
+    analysis = analyzer.analyze_dockerfile(args.dockerfile)
+    analyzer.print_analysis_report(analysis)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a demo `size_optimization_pipeline.py` that runs static and LLM size-only checks, applies fixes, and writes a separate optimized Dockerfile copy
- harden the pipeline flow to handle non-dict LLM responses to avoid attribute errors during runs
- document the demo command in the README for generating size-optimized copies without touching the originals

## Testing
- python -m py_compile llm_agents/*.py dockerfile_optimizer.py parser.py size_static_llm_runner.py llm_size_apply.py llm_size_report.py size_optimization_pipeline.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68c4053c427883298a1f63de018c4fb4)